### PR TITLE
Added indices from 1 to infinity to countable additivity

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -88,7 +88,7 @@ Thus we arrive at the ``measure problem,'' which asks whether it is even possibl
 \begin{enumerate}
 \item (normality) $m(I)=$ the length of $I$ for every interval $I$;
 \item (translation-invariance) $m(x+A)=m(A)$ for every $A$; and
-\item (countable additivity) $m(\bigcup A_n)=\sum m(A_n)$ for every seqence of pairwise disjoint sets $A_n$.
+\item (countable additivity) $m(\bigcup_{n=1}^{\infty} A_n)=\sum m(A_n)$ for every seqence of pairwise disjoint sets $A_n$.
 \end{enumerate}
 
 Perhaps surprisingly, no such measure function $m$ exists! While properties~(a)--(c) seem very natural, the three items unfortunately turn out to be mutually inconsistent.


### PR DESCRIPTION
Some of us mistakenly thought that countable additivity included finite additivity since all finite sets are countable. Adding the indices makes it more consistent with the lecture.